### PR TITLE
fix: AGE session loading for runtime connections

### DIFF
--- a/backend/docker-compose.yaml
+++ b/backend/docker-compose.yaml
@@ -3,7 +3,12 @@
 
 services:
   postgres:
-    image: dawsonlp/mimir-postgres:v3.0.0
+    image: dawsonlp/postgres-batteries-inc:18
+    # AGE requires LOAD 'age' per session for types/operators to be available.
+    # session_preload_libraries ensures this happens automatically for every connection.
+    command: >
+      postgres
+      -c session_preload_libraries=age
     ports:
       - "35432:5432"  # Host:Container - avoid common port conflicts
     volumes:

--- a/backend/init-scripts/01-create-extensions.sql
+++ b/backend/init-scripts/01-create-extensions.sql
@@ -1,14 +1,10 @@
--- Mímir V2 - Initialize PostgreSQL extensions and schema
--- This script runs automatically on first database initialization
+-- Extensions needed by Mimir
+-- All extensions are pre-installed in dawsonlp/postgres-batteries-inc:18
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+CREATE EXTENSION IF NOT EXISTS vector;
+CREATE EXTENSION IF NOT EXISTS age;
 
--- Create dedicated schema for Mímir data (keeps it isolated from public schema)
-CREATE SCHEMA IF NOT EXISTS mimirdata;
-
--- Set search path to include mimirdata schema
-ALTER DATABASE mimir SET search_path TO mimirdata, public;
-
--- pgvector: Vector similarity search for embeddings
-CREATE EXTENSION IF NOT EXISTS vector SCHEMA mimirdata;
-
--- pg_trgm: Trigram-based fuzzy text search (optional but useful)
-CREATE EXTENSION IF NOT EXISTS pg_trgm;
+-- AGE types (agtype, graphid) and operators (graphid_ops) live in ag_catalog.
+-- Add ag_catalog to the database search_path so these are resolvable in every
+-- session without an explicit SET search_path command.
+ALTER DATABASE mimir SET search_path = public, ag_catalog;

--- a/backend/migrations/versions/007_age_graph_projection.up.sql
+++ b/backend/migrations/versions/007_age_graph_projection.up.sql
@@ -1,0 +1,368 @@
+-- Mímir Migration 007: AGE Graph Projection
+-- Projects relational artifacts/relations into per-tenant AGE graphs
+-- See: docs/age-graph-projection-technical-design.md
+--
+-- Requires: Apache AGE extension (already created by init-scripts)
+
+-- =============================================================================
+-- PHASE 1: HELPER FUNCTIONS
+-- =============================================================================
+
+-- Load AGE into the session for this migration
+LOAD 'age';
+SET search_path = ag_catalog, mimirdata, public;
+
+-- -----------------------------------------------------------------------------
+-- create_tenant_graph: Create an AGE graph for a tenant with labels
+-- -----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION mimirdata.create_tenant_graph(p_tenant_id INT)
+RETURNS void AS $$
+DECLARE
+    v_graph_name TEXT := 'mimir_tenant_' || p_tenant_id::text;
+BEGIN
+    -- Create the graph
+    PERFORM ag_catalog.create_graph(v_graph_name);
+
+    -- Create vertex label via placeholder (Cypher auto-creates labels on first use)
+    EXECUTE format(
+        'SELECT * FROM ag_catalog.cypher(%L, $cypher$
+            CREATE (n:Artifact {_init: true})
+            RETURN n
+        $cypher$) AS (v ag_catalog.agtype)',
+        v_graph_name
+    );
+    EXECUTE format(
+        'SELECT * FROM ag_catalog.cypher(%L, $cypher$
+            MATCH (n:Artifact {_init: true})
+            DELETE n
+        $cypher$) AS (v ag_catalog.agtype)',
+        v_graph_name
+    );
+
+    -- Create edge label via placeholder
+    EXECUTE format(
+        'SELECT * FROM ag_catalog.cypher(%L, $cypher$
+            CREATE (a:Artifact {_init_s: true})-[:Relation {_init: true}]->(b:Artifact {_init_t: true})
+            RETURN a
+        $cypher$) AS (v ag_catalog.agtype)',
+        v_graph_name
+    );
+    EXECUTE format(
+        'SELECT * FROM ag_catalog.cypher(%L, $cypher$
+            MATCH (a:Artifact {_init_s: true})-[r:Relation]->(b:Artifact {_init_t: true})
+            DELETE r, a, b
+        $cypher$) AS (v ag_catalog.agtype)',
+        v_graph_name
+    );
+END;
+$$ LANGUAGE plpgsql;
+
+-- -----------------------------------------------------------------------------
+-- drop_tenant_graph: Drop a tenant's AGE graph if it exists
+-- -----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION mimirdata.drop_tenant_graph(p_tenant_id INT)
+RETURNS void AS $$
+DECLARE
+    v_graph_name TEXT := 'mimir_tenant_' || p_tenant_id::text;
+    v_exists BOOLEAN;
+BEGIN
+    SELECT EXISTS(
+        SELECT 1 FROM ag_catalog.ag_graph WHERE name = v_graph_name
+    ) INTO v_exists;
+
+    IF v_exists THEN
+        PERFORM ag_catalog.drop_graph(v_graph_name, true);
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+-- -----------------------------------------------------------------------------
+-- Helper: Escape a text value for embedding in Cypher string literals
+-- Replaces backslash and single-quote to prevent injection
+-- -----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION mimirdata.cypher_escape(val TEXT)
+RETURNS TEXT AS $$
+BEGIN
+    IF val IS NULL THEN
+        RETURN '';
+    END IF;
+    RETURN replace(replace(val, '\', '\\'), '''', '\''');
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+-- -----------------------------------------------------------------------------
+-- rebuild_tenant_graph: Full rebuild from relational data
+-- -----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION mimirdata.rebuild_tenant_graph(p_tenant_id INT)
+RETURNS void AS $$
+DECLARE
+    v_graph_name TEXT := 'mimir_tenant_' || p_tenant_id::text;
+    v_cypher TEXT;
+    rec RECORD;
+BEGIN
+    -- Drop and recreate
+    PERFORM mimirdata.drop_tenant_graph(p_tenant_id);
+    PERFORM mimirdata.create_tenant_graph(p_tenant_id);
+
+    -- Bulk insert all non-deleted artifacts as vertices
+    FOR rec IN
+        SELECT id, artifact_type, title, created_at
+        FROM mimirdata.artifact
+        WHERE tenant_id = p_tenant_id
+          AND deleted_at IS NULL
+    LOOP
+        v_cypher := format(
+            'SELECT * FROM ag_catalog.cypher(%L, $cypher$
+                CREATE (:Artifact {
+                    mimir_id: %s,
+                    artifact_type: %s,
+                    title: %s,
+                    created_at: %s
+                })
+            $cypher$) AS (v ag_catalog.agtype)',
+            v_graph_name,
+            quote_literal(rec.id::text),
+            quote_literal(rec.artifact_type),
+            quote_literal(mimirdata.cypher_escape(COALESCE(rec.title, ''))),
+            quote_literal(rec.created_at::text)
+        );
+        EXECUTE v_cypher;
+    END LOOP;
+
+    -- Bulk insert all relations where both endpoints are non-deleted
+    FOR rec IN
+        SELECT r.id, r.source_id, r.target_id, r.relation_type,
+               r.confidence, r.created_at
+        FROM mimirdata.relation r
+        JOIN mimirdata.artifact sa ON sa.id = r.source_id AND sa.deleted_at IS NULL
+        JOIN mimirdata.artifact ta ON ta.id = r.target_id AND ta.deleted_at IS NULL
+        WHERE r.tenant_id = p_tenant_id
+    LOOP
+        v_cypher := format(
+            'SELECT * FROM ag_catalog.cypher(%L, $cypher$
+                MATCH (s:Artifact {mimir_id: %s}), (t:Artifact {mimir_id: %s})
+                CREATE (s)-[:Relation {
+                    mimir_id: %s,
+                    relation_type: %s,
+                    confidence: %s,
+                    created_at: %s
+                }]->(t)
+            $cypher$) AS (e ag_catalog.agtype)',
+            v_graph_name,
+            quote_literal(rec.source_id::text),
+            quote_literal(rec.target_id::text),
+            quote_literal(rec.id::text),
+            quote_literal(rec.relation_type),
+            COALESCE(rec.confidence, 0.0)::text,
+            quote_literal(rec.created_at::text)
+        );
+        EXECUTE v_cypher;
+    END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+
+-- =============================================================================
+-- PHASE 2: TRIGGER FUNCTIONS
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- Tenant: AFTER INSERT → create graph
+-- -----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION mimirdata.trg_tenant_create_graph()
+RETURNS trigger AS $$
+BEGIN
+    PERFORM mimirdata.create_tenant_graph(NEW.id);
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- -----------------------------------------------------------------------------
+-- Artifact: AFTER INSERT → create vertex
+-- -----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION mimirdata.trg_artifact_create_vertex()
+RETURNS trigger AS $$
+DECLARE
+    v_graph_name TEXT := 'mimir_tenant_' || NEW.tenant_id::text;
+    v_cypher TEXT;
+BEGIN
+    v_cypher := format(
+        'SELECT * FROM ag_catalog.cypher(%L, $cypher$
+            CREATE (:Artifact {
+                mimir_id: %s,
+                artifact_type: %s,
+                title: %s,
+                created_at: %s
+            })
+        $cypher$) AS (v ag_catalog.agtype)',
+        v_graph_name,
+        quote_literal(NEW.id::text),
+        quote_literal(NEW.artifact_type),
+        quote_literal(mimirdata.cypher_escape(COALESCE(NEW.title, ''))),
+        quote_literal(NEW.created_at::text)
+    );
+    EXECUTE v_cypher;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- -----------------------------------------------------------------------------
+-- Artifact: AFTER UPDATE OF deleted_at → remove vertex when soft-deleted
+-- -----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION mimirdata.trg_artifact_soft_delete_vertex()
+RETURNS trigger AS $$
+DECLARE
+    v_graph_name TEXT := 'mimir_tenant_' || NEW.tenant_id::text;
+    v_cypher TEXT;
+BEGIN
+    -- Only act when deleted_at transitions from NULL to a value
+    IF OLD.deleted_at IS NULL AND NEW.deleted_at IS NOT NULL THEN
+        v_cypher := format(
+            'SELECT * FROM ag_catalog.cypher(%L, $cypher$
+                MATCH (a:Artifact {mimir_id: %s})
+                DETACH DELETE a
+            $cypher$) AS (v ag_catalog.agtype)',
+            v_graph_name,
+            quote_literal(NEW.id::text)
+        );
+        EXECUTE v_cypher;
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- -----------------------------------------------------------------------------
+-- Artifact: AFTER DELETE → remove vertex on physical delete
+-- -----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION mimirdata.trg_artifact_delete_vertex()
+RETURNS trigger AS $$
+DECLARE
+    v_graph_name TEXT := 'mimir_tenant_' || OLD.tenant_id::text;
+    v_cypher TEXT;
+BEGIN
+    v_cypher := format(
+        'SELECT * FROM ag_catalog.cypher(%L, $cypher$
+            MATCH (a:Artifact {mimir_id: %s})
+            DETACH DELETE a
+        $cypher$) AS (v ag_catalog.agtype)',
+        v_graph_name,
+        quote_literal(OLD.id::text)
+    );
+    EXECUTE v_cypher;
+
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+-- -----------------------------------------------------------------------------
+-- Relation: AFTER INSERT → create edge
+-- -----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION mimirdata.trg_relation_create_edge()
+RETURNS trigger AS $$
+DECLARE
+    v_graph_name TEXT := 'mimir_tenant_' || NEW.tenant_id::text;
+    v_cypher TEXT;
+BEGIN
+    v_cypher := format(
+        'SELECT * FROM ag_catalog.cypher(%L, $cypher$
+            MATCH (s:Artifact {mimir_id: %s}), (t:Artifact {mimir_id: %s})
+            CREATE (s)-[:Relation {
+                mimir_id: %s,
+                relation_type: %s,
+                confidence: %s,
+                created_at: %s
+            }]->(t)
+        $cypher$) AS (e ag_catalog.agtype)',
+        v_graph_name,
+        quote_literal(NEW.source_id::text),
+        quote_literal(NEW.target_id::text),
+        quote_literal(NEW.id::text),
+        quote_literal(NEW.relation_type),
+        COALESCE(NEW.confidence, 0.0)::text,
+        quote_literal(NEW.created_at::text)
+    );
+    EXECUTE v_cypher;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- -----------------------------------------------------------------------------
+-- Relation: AFTER DELETE → remove edge on physical delete
+-- -----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION mimirdata.trg_relation_delete_edge()
+RETURNS trigger AS $$
+DECLARE
+    v_graph_name TEXT := 'mimir_tenant_' || OLD.tenant_id::text;
+    v_cypher TEXT;
+BEGIN
+    v_cypher := format(
+        'SELECT * FROM ag_catalog.cypher(%L, $cypher$
+            MATCH (s:Artifact {mimir_id: %s})-[r:Relation {mimir_id: %s}]->(t:Artifact {mimir_id: %s})
+            DELETE r
+        $cypher$) AS (e ag_catalog.agtype)',
+        v_graph_name,
+        quote_literal(OLD.source_id::text),
+        quote_literal(OLD.id::text),
+        quote_literal(OLD.target_id::text)
+    );
+    EXECUTE v_cypher;
+
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+
+-- =============================================================================
+-- PHASE 3: ATTACH TRIGGERS
+-- =============================================================================
+
+-- Tenant triggers
+CREATE TRIGGER age_tenant_create_graph
+    AFTER INSERT ON mimirdata.tenant
+    FOR EACH ROW
+    EXECUTE FUNCTION mimirdata.trg_tenant_create_graph();
+
+-- Artifact triggers
+CREATE TRIGGER age_artifact_create_vertex
+    AFTER INSERT ON mimirdata.artifact
+    FOR EACH ROW
+    EXECUTE FUNCTION mimirdata.trg_artifact_create_vertex();
+
+CREATE TRIGGER age_artifact_soft_delete_vertex
+    AFTER UPDATE OF deleted_at ON mimirdata.artifact
+    FOR EACH ROW
+    EXECUTE FUNCTION mimirdata.trg_artifact_soft_delete_vertex();
+
+CREATE TRIGGER age_artifact_delete_vertex
+    AFTER DELETE ON mimirdata.artifact
+    FOR EACH ROW
+    EXECUTE FUNCTION mimirdata.trg_artifact_delete_vertex();
+
+-- Relation triggers
+CREATE TRIGGER age_relation_create_edge
+    AFTER INSERT ON mimirdata.relation
+    FOR EACH ROW
+    EXECUTE FUNCTION mimirdata.trg_relation_create_edge();
+
+CREATE TRIGGER age_relation_delete_edge
+    AFTER DELETE ON mimirdata.relation
+    FOR EACH ROW
+    EXECUTE FUNCTION mimirdata.trg_relation_delete_edge();
+
+
+-- =============================================================================
+-- PHASE 4: BOOTSTRAP EXISTING DATA
+-- =============================================================================
+
+DO $$
+DECLARE
+    v_tenant RECORD;
+BEGIN
+    FOR v_tenant IN SELECT id FROM mimirdata.tenant LOOP
+        PERFORM mimirdata.rebuild_tenant_graph(v_tenant.id);
+    END LOOP;
+END;
+$$;

--- a/backend/src/mimir/database.py
+++ b/backend/src/mimir/database.py
@@ -15,6 +15,24 @@ from mimir.config import get_settings
 _pool: AsyncConnectionPool | None = None
 
 
+async def _configure_connection(conn) -> None:
+    """Configure each new connection from the pool.
+
+    Apache AGE requires LOAD 'age' per session for its types (agtype) and
+    operators (graphid_ops) to be available. While session_preload_libraries
+    in postgresql.conf handles this at the DB level, this callback provides
+    defense-in-depth for the application layer.
+
+    Commits after executing so the connection is returned to the pool in
+    IDLE state (psycopg pool rejects connections left in INTRANS).
+    """
+    await conn.execute("LOAD 'age'")
+    await conn.execute(
+        "SET search_path = ag_catalog, mimirdata, public"
+    )
+    await conn.commit()
+
+
 async def init_pool() -> AsyncConnectionPool:
     """Initialize the async connection pool.
 
@@ -31,6 +49,7 @@ async def init_pool() -> AsyncConnectionPool:
         min_size=2,
         max_size=10,
         open=False,  # Don't open immediately; we'll open explicitly
+        configure=_configure_connection,
     )
     await _pool.open()
     return _pool
@@ -89,6 +108,13 @@ async def health_check() -> dict:
             pgvector_row = await cur.fetchone()
             pgvector_enabled = pgvector_row is not None
 
+            # Check AGE extension
+            await cur.execute(
+                "SELECT extname FROM pg_extension WHERE extname = 'age'"
+            )
+            age_row = await cur.fetchone()
+            age_enabled = age_row is not None
+
             # Get PostgreSQL version
             await cur.execute("SELECT version()")
             version_row = await cur.fetchone()
@@ -98,6 +124,7 @@ async def health_check() -> dict:
             "status": "healthy",
             "database": "connected",
             "pgvector": "enabled" if pgvector_enabled else "disabled",
+            "age": "enabled" if age_enabled else "disabled",
             "postgres_version": pg_version,
         }
     except Exception as e:


### PR DESCRIPTION
## Bug Fix: AGE Extension Not Available in Runtime Sessions

**Priority:** Blocker  
**Reported by:** Agent team after infrastructure rebuild

### Problem

Apache AGE requires `LOAD 'age'` in every PostgreSQL session for its types (`agtype`) and operators (`graphid_ops`) to be available. Migration 007 loaded AGE for its own session, but runtime API connections never loaded it, causing all artifact and tenant creation to fail with 500 errors:

- `operator class "graphid_ops" does not exist for access method "btree"` (tenant creation)
- `type "agtype" does not exist` (artifact creation)

### Root Cause

The `LOAD 'age'` command at the top of migration 007 is session-scoped — it only applies to the migration runner's connection. The API's connection pool creates fresh sessions that never load AGE, so trigger functions that reference `agtype` fail at parse time.

### Fix (defense-in-depth, 4 layers)

| Layer | File | Change |
|-------|------|--------|
| PostgreSQL config | `docker-compose.yaml` | `session_preload_libraries=age` auto-loads AGE in every new session |
| Database defaults | `init-scripts/01-create-extensions.sql` | `ALTER DATABASE mimir SET search_path = public, ag_catalog` |
| Application pool | `src/mimir/database.py` | `_configure_connection()` callback runs `LOAD 'age'` + `SET search_path` on each new pool connection |
| Static SQL | `migrations/007_age_graph_projection.up.sql` | All 11 `agtype` references fully qualified to `ag_catalog.agtype` |

### Verification

Tested from clean rebuild (`docker compose down -v && docker compose up -d`):
- ✅ All 7 migrations applied cleanly
- ✅ Tenant creation succeeds (AGE graph created via trigger)
- ✅ Artifact creation succeeds (AGE vertex created via trigger)
- ✅ Health endpoint now reports AGE extension status